### PR TITLE
blocks, scoping and refactored environments

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -28,4 +28,5 @@ pub enum Stmt {
     Expr(Box<Expr>),
     Print(Box<Expr>),
     Variable { name: Token, initial: Box<Expr> },
+    Block(Vec<Box<Stmt>>),
 }

--- a/src/environment/mod.rs
+++ b/src/environment/mod.rs
@@ -2,49 +2,91 @@ use crate::errors::RuntimeError;
 use crate::tokens::{Kind, Token};
 use crate::value::Value;
 
+use crate::errors::RuntimeError::UndefinedVariable;
 use std::collections::HashMap;
 
-pub struct Environment {
+pub struct Environments {
+    envs: Vec<Environment>,
+}
+
+impl Environments {
+    pub fn new() -> Self {
+        Self {
+            envs: vec![Environment::new()],
+        }
+    }
+
+    pub fn add_env(&mut self) {
+        self.envs.push(Environment::new());
+    }
+
+    /// Define variable within outermost environment.
+    pub fn define(&mut self, ident: Token, value: Value) {
+        match ident.kind {
+            Kind::Identifier(i) => self.envs.last_mut().unwrap().define(i, value),
+            _ => unreachable!(),
+        };
+    }
+
+    /// Retrieve variable starting from outermost environment, working inwards.
+    pub fn get(&self, ident: Token) -> Result<Value, RuntimeError> {
+        match ident.kind {
+            Kind::Identifier(ref i) => {
+                for env in self.envs.iter().rev() {
+                    if let Some(value) = env.get(i) {
+                        return Ok(value);
+                    }
+                }
+
+                Err(UndefinedVariable { received: ident })
+            }
+
+            _ => unreachable!(),
+        }
+    }
+
+    /// Assign a variable, searching for binding from the outermost environment and working inwards.
+    pub fn assign(&mut self, ident: Token, value: Value) -> Result<Value, RuntimeError> {
+        match ident.kind {
+            Kind::Identifier(ref i) => {
+                for env in self.envs.iter_mut().rev() {
+                    if let Some(out) = env.assign(i, &value) {
+                        return Ok(out);
+                    }
+                }
+
+                Err(UndefinedVariable { received: ident })
+            }
+
+            _ => unreachable!(),
+        }
+    }
+}
+
+struct Environment {
     values: HashMap<String, Value>,
 }
 
 impl Environment {
-    pub fn new() -> Self {
+    fn new() -> Self {
         Self {
             values: HashMap::new(),
         }
     }
 
-    pub fn define(&mut self, name: String, value: Value) {
+    fn define(&mut self, name: String, value: Value) {
         self.values.insert(name, value);
     }
 
-    pub fn get(&self, ident: Token) -> Result<Value, RuntimeError> {
-        match ident {
-            Token {
-                kind: Kind::Identifier(ref name),
-                ..
-            } => self
-                .values
-                .get(name)
-                .cloned()
-                .ok_or(RuntimeError::UndefinedVariable { received: ident }),
-
-            _ => unreachable!(),
-        }
+    fn get(&self, ident: &str) -> Option<Value> {
+        self.values.get(ident).cloned()
     }
 
-    pub fn assign(&mut self, ident: Token, value: Value) -> Result<Value, RuntimeError> {
-        match ident.kind {
-            Kind::Identifier(ref name) => {
-                if self.values.contains_key(name) {
-                    Ok(self.values.insert(name.clone(), value).unwrap())
-                } else {
-                    Err(RuntimeError::UndefinedVariable { received: ident })
-                }
-            }
-
-            _ => unreachable!(),
+    fn assign(&mut self, ident: &str, value: &Value) -> Option<Value> {
+        if self.values.contains_key(ident) {
+            return self.values.insert(ident.to_string(), value.clone());
         }
+
+        None
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(in_band_lifetimes)]
+
 pub mod ast;
 pub mod environment;
 pub mod errors;


### PR DESCRIPTION
blocks and scope added

environment refactored to be simpler and more efficient. no longer using a parent pointer tree like the book uses due to added code complexity thanks to lifetimes and needing mutable references to parent environments. Now uses an array-based stack.